### PR TITLE
Fix asset upgrade error and build setup

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -7,7 +7,7 @@ $enable-shadows: true;
 $card-border-width: 0;
 $link-decoration: none;
 
-@import '@tabler/core/src/scss/core';
+@import '@tabler/core/scss/core';
 
 html,
 body {


### PR DESCRIPTION
The @tabler/core package structure changed in the newer version. The SCSS files are now located at @tabler/core/scss/ instead of @tabler/core/src/scss/. This was causing webpack to fail with "Can't find stylesheet to import" error.

Updated the import path in assets/scss/app.scss from: @import '@tabler/core/src/scss/core';

to:
@import '@tabler/core/scss/core';

Verified that both yarn dev and yarn build now compile successfully.