### PR TITLE
Consolidate Claude workflow tool configuration into claude_args

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,5 +41,4 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          allowed_tools: "Bash(composer:*),Bash(yarn:*),Bash(gh:*)"
-          claude_args: "--model claude-opus-4-5-20251101"
+          claude_args: "--model claude-opus-4-5-20251101 --allowed-tools Bash(composer:*),Bash(yarn:*),Bash(gh:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          allowed_tools: "Bash(composer:*),Bash(yarn:*),Bash(gh:*)"
-          claude_args: "--model claude-opus-4-5-20251101"
+          claude_args: "--model claude-opus-4-5-20251101 --allowed-tools Bash(composer:*),Bash(yarn:*),Bash(gh:*)"


### PR DESCRIPTION
## Summary
Refactored the Claude code action workflows to consolidate tool configuration by moving the `allowed_tools` parameter into the `claude_args` string, aligning with the latest Claude code action API.

## Changes
- **claude-code-review.yml**: Merged `allowed_tools` into `claude_args` as `--allowed-tools` flag
- **claude.yml**: Merged `allowed_tools` into `claude_args` as `--allowed-tools` flag
- Maintained the same tool permissions: `Bash(composer:*),Bash(yarn:*),Bash(gh:*)`
- Kept the model specification: `claude-opus-4-5-20251101`

## Details
This change simplifies the workflow configuration by using a single `claude_args` parameter instead of separate `allowed_tools` and `claude_args` fields. The functionality remains identical, but the configuration is now more streamlined and follows the current Claude code action conventions.