### PR TITLE
chore: add composer validate & normalize CI check

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -10,7 +10,7 @@
         {
             "name": "Composer validate & normalize",
             "job": {
-                "command": "composer validate --strict --no-check-publish && composer normalize --dry-run --diff",
+                "command": "composer validate --strict && composer normalize --dry-run --diff",
                 "php": "@lowest",
                 "dependencies": "locked"
             }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "silarhi/symfony-docker-ci",
+    "description": "Symfony Docker CI application",
     "license": "MIT",
     "type": "project",
     "require": {
@@ -8,7 +10,7 @@
         "bacon/bacon-qr-code": "^3.1.1",
         "league/commonmark": "^2.8.2",
         "league/glide-symfony": "^2.1.0",
-        "pragmarx/google2fa": "^9",
+        "pragmarx/google2fa": "^9.0",
         "silarhi/picasso-bundle": "^1.1.0",
         "symfony/asset": "~8.1.0",
         "symfony/console": "~8.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fc2082af0b795a482b226a9e06072fe",
+    "content-hash": "e555b709651abee91be5a48d063eacbc",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/config/reference.php
+++ b/config/reference.php
@@ -1,12 +1,6 @@
 <?php
 
-/*
- * This file is part of SILARHI.
- * (c) 2019 - present Guillaume Sainthillier <guillaume@silarhi.fr>
- *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
- */
+// This file is auto-generated and is for apps only. Bundles SHOULD NOT rely on its content.
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 

--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,7 @@
     "paths": {
         "@/*": ["assets/*"]
     },
-    "ignoreBinaries": ["vendor/bin/.+"],
+    "ignoreBinaries": ["composer", "vendor/bin/.+"],
     "rules": {
         "unlisted": "off",
         "unresolved": "off"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "*.{js,jsx,ts,tsx,mjs,json}": "biome check --write --no-errors-on-unmatched",
         "*.{scss,md,yaml,yml}": "prettier --write",
         "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",
-        "*.twig": "vendor/bin/twig-cs-fixer lint --fix --config=.twig-cs-fixer.php"
+        "*.twig": "vendor/bin/twig-cs-fixer lint --fix --config=.twig-cs-fixer.php",
+        "composer.json": "composer normalize"
     },
     "devDependencies": {
         "@babel/core": "^7.28.5",


### PR DESCRIPTION
Adds composer.json quality enforcement, consistent with `silarhi/picasso-bundle`:

- `ergebnis/composer-normalize` dev dependency + its `allow-plugins` entry
- lint-staged hook running `composer normalize` on `composer.json`
- laminas-ci `additional_checks` step running `composer validate --strict && composer normalize --dry-run --diff`
- `composer.lock` content-hash refreshed
