### PR TITLE
style: resolve biome lint issues in assets

### DIFF
--- a/assets/controllers/csrf_protection_controller.js
+++ b/assets/controllers/csrf_protection_controller.js
@@ -45,7 +45,10 @@ export function generateCsrfToken(formElement) {
     csrfField.dispatchEvent(new Event('change', { bubbles: true }))
 
     if (csrfCookie && tokenCheck.test(csrfToken)) {
+        // biome-ignore lint/style/useTemplate: keep verbatim Symfony stimulus-bundle CSRF controller
         const cookie = csrfCookie + '_' + csrfToken + '=' + csrfCookie + '; path=/; samesite=strict'
+        // biome-ignore lint/style/useTemplate: keep verbatim Symfony stimulus-bundle CSRF controller
+        // biome-ignore lint/suspicious/noDocumentCookie: double-submit CSRF cookie must be written synchronously (Cookie Store API is async/unsupported in Firefox)
         document.cookie = window.location.protocol === 'https:' ? '__Host-' + cookie + '; secure' : cookie
     }
 }
@@ -77,8 +80,11 @@ export function removeCsrfToken(formElement) {
     const csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value')
 
     if (tokenCheck.test(csrfField.value) && nameCheck.test(csrfCookie)) {
+        // biome-ignore lint/style/useTemplate: keep verbatim Symfony stimulus-bundle CSRF controller
         const cookie = csrfCookie + '_' + csrfField.value + '=0; path=/; samesite=strict; max-age=0'
 
+        // biome-ignore lint/style/useTemplate: keep verbatim Symfony stimulus-bundle CSRF controller
+        // biome-ignore lint/suspicious/noDocumentCookie: double-submit CSRF cookie must be written synchronously (Cookie Store API is async/unsupported in Firefox)
         document.cookie = window.location.protocol === 'https:' ? '__Host-' + cookie + '; secure' : cookie
     }
 }

--- a/assets/js/component/Item.jsx
+++ b/assets/js/component/Item.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import React from 'react'
 
 export default function Items({ id, title, body }) {
     return (

--- a/assets/js/pages/index.jsx
+++ b/assets/js/pages/index.jsx
@@ -1,5 +1,4 @@
 import { Controller } from '@hotwired/stimulus'
-import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from '@/js/component/App'
 


### PR DESCRIPTION
## Summary

Clears all 8 Biome lint violations so `yarn lint-ci` passes clean.

| File | Fix |
|---|---|
| `assets/js/component/Item.jsx` | Removed unused `import React` |
| `assets/js/pages/index.jsx` | Removed unused `import React` |
| `assets/controllers/csrf_protection_controller.js` | Inline `biome-ignore` for `useTemplate` (×4) and `noDocumentCookie` (×2) |

## Notes

- The unused `React` imports are dead under React 19's automatic JSX runtime — Webpack/Babel inject `react/jsx-runtime` instead of `React.createElement`, so `React` is never referenced.
- `csrf_protection_controller.js` is Symfony's stock `stimulus-bundle` CSRF controller. Rather than refactor vendored, security-sensitive code, the violations are suppressed inline so the file stays byte-identical to upstream apart from the comments:
  - `noDocumentCookie` has no autofix; the suggested Cookie Store API is async and unsupported in Firefox, which would break the synchronous double-submit cookie write.
  - `useTemplate` only fired in this vendored file.

## Test plan

- [x] `yarn lint-ci` → `Checked 8 files… No fixes applied` (clean)
- [x] Husky pre-commit hook (lint-staged + biome) passed